### PR TITLE
Fix for issue with imprecise time values

### DIFF
--- a/service.qlock/default.py
+++ b/service.qlock/default.py
@@ -68,6 +68,7 @@ def drawBackground(background):
     WINDOW.setProperty( "Qlock.%i.Background" % (i+1), background[i])
     
 def drawHighlight(background, dom):
+  global now
   now = datetime.datetime.now()   
   for i in range (1,111):
     WINDOW.clearProperty("Qlock.%i.Highlight" % i) 


### PR DESCRIPTION
The global "now" variable was not declared as global inside a function where the update happens. This lead to frequent peaks where the time displayed was 5 minute behind the actual time.
Btw. I love the qlock, it is a beautiful, "exclusive" screen-saver, thanks for the work!
